### PR TITLE
Add django 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - DJANGO=1.5
   - DJANGO=1.6
   - DJANGO=1.7
+  - DJANGO=1.8
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install pep8 --use-mirrors

--- a/rules_light/class_decorator.py
+++ b/rules_light/class_decorator.py
@@ -22,8 +22,12 @@ def patch_get_object(cls, suffix, override):
         if self.get_object._rule_override:
             rule_name = self.get_object._rule_override
         else:
+            try:
+                model_name = obj.__class__._meta.model_name
+            except AttributeError:
+                model_name = obj.__class__._meta.module_name
             rule_name = '%s.%s.%s' % (obj.__class__._meta.app_label,
-                obj.__class__._meta.model_name, self.get_object._rule_suffix)
+                model_name, self.get_object._rule_suffix)
 
         registry.require(self.request.user, rule_name, obj)
 
@@ -76,8 +80,12 @@ class class_decorator(object):
 
             def new_get_form(self, form_class, *args, **kwargs):
                 model = form_class.Meta.model
+                try:
+                    model_name = model._meta.model_name
+                except AttributeError:
+                    model_name = model._meta.module_name
                 rule_name = '%s.%s.create' % (model._meta.app_label,
-                    model._meta.model_name)
+                    model_name)
 
                 registry.require(self.request.user, rule_name)
 

--- a/rules_light/class_decorator.py
+++ b/rules_light/class_decorator.py
@@ -23,7 +23,7 @@ def patch_get_object(cls, suffix, override):
             rule_name = self.get_object._rule_override
         else:
             rule_name = '%s.%s.%s' % (obj.__class__._meta.app_label,
-                obj.__class__._meta.module_name, self.get_object._rule_suffix)
+                obj.__class__._meta.model_name, self.get_object._rule_suffix)
 
         registry.require(self.request.user, rule_name, obj)
 
@@ -77,7 +77,7 @@ class class_decorator(object):
             def new_get_form(self, form_class, *args, **kwargs):
                 model = form_class.Meta.model
                 rule_name = '%s.%s.create' % (model._meta.app_label,
-                    model._meta.module_name)
+                    model._meta.model_name)
 
                 registry.require(self.request.user, rule_name)
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -2,10 +2,13 @@
 
 import os.path
 import posixpath
+import django
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+if django.VERSION >=(1,6):
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG


### PR DESCRIPTION
For compatibility with django 1.8, see
https://docs.djangoproject.com/fr/1.8/internals/deprecation/#deprecation-removed-in-1-8