### PR TITLE
Fix small bug with 4.1 and prepare v.0.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.3.2 Django 4.1.x support
+
 0.3.1 Django 4.x support
 Provide context for error page by @martinmaillard
 

--- a/rules_light/templatetags/rules_light_tags.py
+++ b/rules_light/templatetags/rules_light_tags.py
@@ -40,4 +40,4 @@ class Rule(AsTag):
                     *args, **kwargs)
 
 
-register.tag(Rule)
+register.tag('rule', Rule)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if 'sdist' in sys.argv:
 
 setup(
     name='django-rules-light',
-    version='0.3.1',
+    version='0.3.2',
     description='Rule registry for django',
     author='James Pic',
     author_email='jamespic@gmail.com',


### PR DESCRIPTION
Hey @jpic hope you are fine!

It seems that we need to explicitly pass the tag name in order to register in Django 4.1... Could you please merge this and release v0.3.2 ? 

Thank you !